### PR TITLE
feat: Implement ImageTool uploader and verify editor cleanup

### DIFF
--- a/src/frontend/views/NoteEditorView.tsx
+++ b/src/frontend/views/NoteEditorView.tsx
@@ -45,11 +45,15 @@ const EDITOR_TOOLS = {
             const arrayBuffer = await file.arrayBuffer();
             
             // Call the new Electron API (hypothetical at this stage for main process)
-            const result = await window.electronAPI.saveImage({
-              buffer: arrayBuffer,
-              name: file.name,
-              type: file.type,
-            });
+            // MODIFIED LINE: Ensure projectRootPath is the first argument
+            const result = await window.electronAPI.saveImage(
+              projectRootPath, 
+              {
+                buffer: arrayBuffer,
+                name: file.name,
+                type: file.type,
+              }
+            );
 
             if (result.success && result.url) {
               return {


### PR DESCRIPTION
This commit finalizes key aspects of the Editor.js integration:

- **ImageTool Uploader (`NoteEditorView.tsx`):**
    - Refined the `ImageTool` configuration to correctly call the `window.electronAPI.saveImage` function.
    - The uploader now passes `projectRootPath` along with image data (buffer, name, type) to the Electron API.
    - Defined the expected specification for the `saveImage` API handler in the Electron main process, including asset path construction (projectRootPath/.assets/images), unique filename generation, and returning a `file://` URL. (Main process implementation of this API is a separate task).

- **Editor.js Cleanup Logic (`EditorWrapper`):**
    - Reviewed and confirmed that the existing cleanup logic is sound.
    - The use of `key={currentFilePath}` on the `EditorWrapper` ensures that the Editor.js instance is properly destroyed and re-created when switching notes.
    - The `useEffect` cleanup within `EditorWrapper` correctly calls `editor.destroy()`.

- **Testing Outline:**
    - Developed a comprehensive list of conceptual test scenarios for end-to-end validation of the Editor.js integration.

This significantly advances the Editor.js feature, with the renderer-side setup for image handling now complete, pending main process API implementation.