### PR TITLE
docs: Define auth system backend spec and frontend store structure

### DIFF
--- a/src/frontend/store/useAuthStore.ts
+++ b/src/frontend/store/useAuthStore.ts
@@ -1,0 +1,148 @@
+// src/frontend/store/useAuthStore.ts
+import { create } from 'zustand';
+import { User } from '../types/user'; // Adjust path if your folder structure is different
+
+// TODO: Define these properly, perhaps in a separate types file shared with views
+export interface LoginCredentials { email: string; password: string; }
+export interface RegisterData { email: string; password: string; displayName?: string; }
+
+interface AuthState {
+  user: User | null;
+  token: string | null;
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  error: string | null;
+  setUser: (user: User | null) => void;
+  setToken: (token: string | null) => void;
+  setIsLoading: (loading: boolean) => void;
+  setError: (error: string | null) => void;
+  clearAuthError: () => void;
+  login: (credentials: LoginCredentials) => Promise<void>;
+  register: (data: RegisterData) => Promise<void>;
+  loginWithGoogle: () => Promise<void>;
+  loginWithGitHub: () => Promise<void>;
+  handleOAuthToken: (token: string) => Promise<void>;
+  logout: () => Promise<void>;
+  loadUserFromToken: () => Promise<void>;
+}
+
+const useAuthStore = create<AuthState>((set, get) => ({
+  user: null,
+  token: null,
+  isAuthenticated: false,
+  isLoading: false,
+  error: null,
+
+  setUser: (user) => set({ user, isAuthenticated: !!user }),
+  setToken: (token) => {
+    set({ token });
+    if (token) {
+      // TODO: Persist token to secure storage (e.g., Electron Store or keytar)
+      console.log("Token set. TODO: Persist to secure storage.");
+    } else {
+      // TODO: Remove token from secure storage
+      console.log("Token cleared. TODO: Remove from secure storage.");
+    }
+  },
+  setIsLoading: (loading) => set({ isLoading: loading }),
+  setError: (error) => set({ error, isLoading: false }), // Also set isLoading false on error
+  clearAuthError: () => set({ error: null }),
+
+  login: async (credentials) => {
+    set({ isLoading: true, error: null });
+    console.log('Attempting login with:', credentials);
+    // Placeholder for API call
+    // Simulating API call
+    await new Promise(resolve => setTimeout(resolve, 1000));
+    // Simulate success:
+    // const mockUser: User = { id: 'user-local-123', email: credentials.email, provider: 'local', displayName: 'Logged In User' };
+    // const mockToken = 'mock-jwt-token-local';
+    // get().setUser(mockUser);
+    // get().setToken(mockToken);
+    // set({ isLoading: false });
+    // Simulate failure:
+    set({ error: 'Login failed (placeholder)', isLoading: false });
+    console.log('login action placeholder executed');
+  },
+
+  register: async (data) => {
+    set({ isLoading: true, error: null });
+    console.log('Attempting registration with:', data);
+    // Placeholder for API call
+    await new Promise(resolve => setTimeout(resolve, 1000));
+    set({ error: 'Registration failed (placeholder)', isLoading: false });
+    console.log('register action placeholder executed');
+  },
+
+  loginWithGoogle: async () => {
+    set({ isLoading: true, error: null });
+    console.log('loginWithGoogle action placeholder. TODO: IPC to main process.');
+    // Simulate that main process interaction is pending
+    // isLoading will be set to false by handleOAuthToken or if an error occurs in this setup phase
+  },
+
+  loginWithGitHub: async () => {
+    set({ isLoading: true, error: null });
+    console.log('loginWithGitHub action placeholder. TODO: IPC to main process.');
+  },
+
+  handleOAuthToken: async (token: string) => {
+    set({ isLoading: true, error: null });
+    console.log('handleOAuthToken received token (simulated):', token);
+    // In a real scenario, you'd use this token to fetch user profile from your backend
+    // For example: GET /auth/profile with Authorization: Bearer <token>
+    // That backend call would return your app's own JWT and user object if successful.
+    // Here, we'll simulate that process.
+    await new Promise(resolve => setTimeout(resolve, 500));
+    if (token && token.startsWith("simulated-oauth-token-")) { // Check if it's a simulated valid token
+      const provider = token.includes("google") ? "google" : "github";
+      const mockUser: User = { 
+        id: `user-${provider}-123`, 
+        email: `${provider}user@example.com`, 
+        provider: provider, 
+        displayName: `${provider.charAt(0).toUpperCase() + provider.slice(1)} User` 
+      };
+      const appSpecificJwt = `mock-app-jwt-for-${provider}-${Date.now()}`;
+      
+      get().setToken(appSpecificJwt); // Set our app's JWT
+      get().setUser(mockUser);
+      set({ isLoading: false });
+      console.log(`OAuth flow for ${provider} successful. App token and user set.`);
+    } else {
+      get().setToken(null);
+      get().setUser(null);
+      set({ error: 'Failed to validate OAuth session or invalid token received.', isLoading: false });
+    }
+  },
+
+  logout: async () => {
+    console.log('logout action: clearing user and token.');
+    // TODO: Call backend /auth/logout if it exists
+    get().setUser(null);
+    get().setToken(null); // This will trigger the TODO for removing from storage
+  },
+
+  loadUserFromToken: async () => {
+    // TODO: Load token from secure storage
+    // const storedToken = await someAsyncSecureStorage.getItem('app_token');
+    const storedToken: string | null = null; // Placeholder: no token found initially
+    console.log('loadUserFromToken: checking for stored token (simulated).');
+
+    if (storedToken) {
+      set({ isLoading: true });
+      // Placeholder: validate token and fetch user profile
+      await new Promise(resolve => setTimeout(resolve, 500));
+      // Simulate token validation and profile fetch
+      // const mockUser: User = { id: 'user-loaded-123', email: 'loaded@example.com', provider: 'local', displayName: 'Loaded User' };
+      // get().setToken(storedToken);
+      // get().setUser(mockUser);
+      // set({ isLoading: false });
+      console.log('loadUserFromToken: Token found and user loaded (simulated).');
+    } else {
+      console.log('loadUserFromToken: No stored token found.');
+      // No need to set isLoading if no token, as nothing is being loaded.
+    }
+  },
+}));
+
+export default useAuthStore;

--- a/src/frontend/types/user.ts
+++ b/src/frontend/types/user.ts
@@ -1,0 +1,11 @@
+// src/frontend/types/user.ts
+export interface User {
+  id: string;
+  email: string;
+  displayName?: string;
+  provider: string; // 'local', 'google', 'github'
+  avatarUrl?: string;
+  profile?: any; // Additional profile data
+  createdAt?: Date; 
+  updatedAt?: Date;
+}


### PR DESCRIPTION
Defines the backend API specifications and frontend Zustand store structure for the new authentication system. This includes local (email/password) and social (Google/GitHub OAuth 2.0) authentication.

**Backend Specifications (Fase 1 - Definitional):**
- **User Entity (TypeORM):** Defined fields (id, email, password, provider, providerId, displayName, avatarUrl, timestamps, profile jsonb) and decorators/indexing for a User entity.
- **Local Auth API Endpoints:** Specified for `/auth/register`, `/auth/login`, and `/auth/profile` (protected), including request/response structures and error codes.
- **OAuth 2.0 API Endpoints:** Specified for `/auth/google`, `/auth/google/callback`, `/auth/github`, `/auth/github/callback`. Noted redirection flow and JWT return mechanism to Electron.
- **JWT & Hashing:** Specified use of JWT (with env vars for secret/expiry) and bcrypt for password hashing.

**Frontend Setup (Fase 2 - Initial):**
- **`User` Type (`src/frontend/types/user.ts`):** Created frontend User interface.
- **`useAuthStore.ts` (`src/frontend/store/useAuthStore.ts`):**
    - Created Zustand store with initial state (`user`, `token`, `isAuthenticated`, `isLoading`, `error`).
    - Defined basic setters and placeholder async actions for `login`, `register`, `loginWithGoogle`, `loginWithGitHub`, `handleOAuthToken`, `logout`, and `loadUserFromToken`.
- **Renderer-Side OAuth Logic (Conceptual):** Outlined that `loginWithGoogle` and `loginWithGitHub` actions will use `ipcRenderer.invoke` to trigger the main process, and an IPC listener will handle the returned token by calling `handleOAuthToken`.
- **Main Process OAuth Handling (Conceptual):** Outlined how the Electron main process should manage the OAuth browser window, intercept callbacks, and send the token to the renderer.

This commit represents the completion of the initial design and frontend store scaffolding for the authentication feature. Further implementation will involve backend development, Electron main process IPC for OAuth, UI views, and filling in the placeholder actions in `useAuthStore`.